### PR TITLE
Add glob-all to build package.json

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -15,6 +15,7 @@
   "author": "Peter Banka",
   "license": "MIT",
   "devDependencies": {
+    "glob-all": "^3.0.1",
     "gm": "1.18.1",
     "http-server": "^0.8.5",
     "jasmine": "^2.4.1",


### PR DESCRIPTION
This is a #minor# change that allows clients to use the `glob-all`
package in their test files.