### PR TITLE
Multi server e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dump.rdb
 config.json
 npm-debug.log
 typings/
+build-*/
+test.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 dump.rdb
 config.json
 npm-debug.log
+typings/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ typings/
 build-*/
 test.tar.gz
 *.tar
+servers.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vendor/
 screenshots/
 uploads/
 coverage/
+coverage-backend/
 dist/
 .DS_Store
 dump.rdb

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ npm-debug.log
 typings/
 build-*/
 test.tar.gz
+*.tar

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "editor.tabCompletion": true
+}

--- a/SETUP.md
+++ b/SETUP.md
@@ -28,6 +28,14 @@ This script should configure everything, including Node, Redis, xvfb, and Java
 
 If there is any need to enter the tmux session again, run the command ```tmux attach-session```
 
+##### Configuring the webdriverio-server to use forever js
+Forever.js is another solution which is very easy to setup and might become the default way to run a program in the background. However, it is not as 
+easy to find the output logs, since the output is not directory to the console.
+1. Run the command ```npm install -g forever```
+2. Run the command ```forever start webdriverio-server```
+
+This should run webdriverio-server as a service forever. If you want to stop the service, run `forever stop webdriverio-server`. More details on forever can be found [here](https://github.com/foreverjs/forever/blob/master/README.md)
+
 #### Configuring the RedisDB to use a password
 In Ubuntu, the redis.conf file, or the redis configuration file is stored at this location ```/etc/redis```  
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -66,6 +66,19 @@ This is ignored on the webdriverio-server repository, but it is required when ru
 }
 ```
 
+#### Configuring the set of slave servers
+When using the multi server solution, where a master server sends tests to slave servers, a json file is required.
+
+```
+{
+  "potentialServers": [
+    "localhost:3000",
+    "localhost:4000"
+  ]
+}
+```
+This file needs to be called servers.json and must be stored in the base directory.
+
 #### Congiuring Travis CI
 When running e2e tests on TravisCI, we using the commit number to determine the username of the person who committed the code. This means we use the GitHub api to 
 determine this information. However, the GitHub api limits the number of hits by a given IP address to 60 per hour. This means that Travis is limited when connecting

--- a/bin/bootstrap/ubuntu/14.04.sh
+++ b/bin/bootstrap/ubuntu/14.04.sh
@@ -2,6 +2,7 @@
 set -ex
 
 MASTER=$1
+
 { # this ensures the entire script is downloaded
 
 # Install the base dependencies
@@ -166,7 +167,7 @@ npm install -g webdriverio-server && webdriverio-server-init
 echo "source ~/.bashrc" >> ~/.bash_profile
 echo 'export NVM_DIR="$HOME/.nvm' >> ~/.bashrc
 echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh' >> ~/.bashrc
-echo 'MASTER=$MASTER' >> ~/.bashrc
+echo 'export MASTER='${MASTER} >> ~/.bashrc
 echo "Please source ~/.bashrc to complete setup"
 echo "After the initial run, to run it again, you should only need:"
 echo "\$ source ~/.bashrc && DISPLAY=:0 DEBUG=server webdriverio-server"

--- a/bin/bootstrap/ubuntu/14.04.sh
+++ b/bin/bootstrap/ubuntu/14.04.sh
@@ -35,7 +35,7 @@ nvm install 5.11.0
 
 # Install xvfb, chrome and firefox
 sudo sh -c 'curl -sL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 sudo apt-get update
 sudo apt-get install -y xvfb firefox google-chrome-stable
 sudo apt-get clean

--- a/bin/bootstrap/ubuntu/14.04.sh
+++ b/bin/bootstrap/ubuntu/14.04.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -ex
+
+MASTER=$1
 { # this ensures the entire script is downloaded
 
 # Install the base dependencies
@@ -164,6 +166,7 @@ npm install -g webdriverio-server && webdriverio-server-init
 echo "source ~/.bashrc" >> ~/.bash_profile
 echo 'export NVM_DIR="$HOME/.nvm' >> ~/.bashrc
 echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh' >> ~/.bashrc
+echo 'MASTER=$MASTER' >> ~/.bashrc
 echo "Please source ~/.bashrc to complete setup"
 echo "After the initial run, to run it again, you should only need:"
 echo "\$ source ~/.bashrc && DISPLAY=:0 DEBUG=server webdriverio-server"

--- a/handlers/developers-handler.js
+++ b/handlers/developers-handler.js
@@ -190,6 +190,9 @@ function getResponse (err, res, req, redisResp) {
                                            'Please make sure that you are signed up as an authorized ' +
                                            'ciena developer on www.cienadevelopers.com', 500)
     return {reject: 'This username does not exist: ' + req.query.username}
+  } else if (redisResp === '~' || req.query.token === '~') {
+    DeveloperHandler.setErrorResponse(res, 'This account has been restricted', 500)
+    return {reject: 'This account has been restricted'}
   } else if (req.query.token === '' || req.query.token === redisResp) {
     DeveloperHandler.setStandardResponse(res, req.query.username, redisResp)
     return {resolve: req.query.token}

--- a/handlers/ip-handler.js
+++ b/handlers/ip-handler.js
@@ -1,4 +1,5 @@
 'use strict'
+const MASTER = true
 const fs = require('fs')
 const path = require('path')
 
@@ -98,6 +99,9 @@ const IPHandler = {
    * or reject if there are errors
    */
   post: function (req, res) {
+    if (!MASTER) {
+      this.startTest(req, res)
+    }
     return new Promise((resolve, reject) => {
       if (!req.headers) {
         res.send('Error: Headers do not exist')

--- a/handlers/ip-handler.js
+++ b/handlers/ip-handler.js
@@ -1,5 +1,5 @@
 'use strict'
-const MASTER = true
+const MASTER = process.env['MASTER']
 const fs = require('fs')
 const path = require('path')
 

--- a/handlers/ip-handler.js
+++ b/handlers/ip-handler.js
@@ -25,7 +25,7 @@ const IPHandler = {
    */
   checkIP: function (req) {
     return new Promise((resolve, reject) => {
-      const ip = req.headers['x-forwarded-for'].toString()
+      const ip = req.headers['x-forwarded-for']
       if (!ip) {
         reject(`Please set headers for proxy connections using nginx!\n
         A helpful article on setting this up: https://www.digitalocean.com/community/tutorials/
@@ -45,7 +45,7 @@ const IPHandler = {
           token
         }
       }
-      if (fileContents.indexOf(ip) !== -1) {
+      if (fileContents.indexOf(ip.toString()) !== -1) {
         DeveloperHandler.get(request).then(() => {
           reject('Your account is restricted. Your username is ' + username + ' and your token is ' + token)
         })

--- a/handlers/ip-handler.js
+++ b/handlers/ip-handler.js
@@ -99,26 +99,25 @@ const IPHandler = {
    * or reject if there are errors
    */
   post: function (req, res) {
+    console.log('Getting request')
     if (!MASTER) {
+      console.log('This is a slave server, starting tests...')
       this.startTest(req, res)
-    }
-    return new Promise((resolve, reject) => {
+    } else {
+      console.log('This is a master server. Checking the IP of the incoming request...')
       if (!req.headers) {
         res.send('Error: Headers do not exist')
         res.end()
-        reject()
       } else {
         this.checkIP(req)
         .then((result) => {
           if (result === true) {
             this.startTest(req, res)
-            resolve()
           } else {
             this.checkUsername(req, res).then(() => {
-              resolve()
             })
-            .catch(() => {
-              reject()
+            .catch((err) => {
+              throw new Error(err)
             })
           }
         })
@@ -126,11 +125,11 @@ const IPHandler = {
           if (err) {
             res.send(err)
             res.end()
-            reject()
+            console.log(err)
           }
         })
       }
-    })
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "debug": "~2.1.1",
     "express": "~4.12.2",
     "express-session": "^1.10.1",
+    "fs-extra": "^0.30.0",
     "github": "^2.0.1",
     "jade": "~1.9.2",
     "lodash": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "ember-cli-mocha": "^0.10.4",
     "ember-cli-moment-shim": "2.0.0",
     "ember-cli-release": "0.2.8",
-    "ember-cli-sass": "^5.3.1",
+    "ember-cli-sass": "5.4.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-computed-decorators": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -58,15 +58,16 @@
     "jade": "~1.9.2",
     "lodash": "^4.3.0",
     "method-override": "^2.3.6",
-    "morgan": "~1.5.1",
     "mongoose": "^4.4.1",
+    "morgan": "~1.5.1",
     "multer": "^0.1.8",
     "oauth": "^0.9.14",
-    "q": "^1.4.1",
-    "redis": "^2.6.1",
     "passport": "^0.2.1",
     "passport-local": "^1.0.0",
-    "serve-favicon": "~2.2.0"
+    "q": "^1.4.1",
+    "redis": "^2.6.1",
+    "serve-favicon": "~2.2.0",
+    "tar": "^2.2.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "start": "npm run build && node ./bin/www.js",
     "lint": "eslint *.js bin public test routes src spec testUtils handlers && npm run lint-sass",
-    "jasmine": "JASMINE_CONFIG_PATH=spec/support/jasmine.json istanbul cover $npm_config_coverage_opts jasmine",
-    "test": "npm run lint && npm run ember-test && npm run jasmine && npm run b2e-test",
+    "jasmine": "JASMINE_CONFIG_PATH=spec/support/jasmine.json istanbul cover --dir coverage-backend jasmine",
+    "test": "npm run lint && npm run ember-test && npm run jasmine && npm run b2e-test && npm run combine-coverage",
     "ember-test": "COVERAGE=true ember test",
     "e2e-test": "wdio-client remote_e2e_test wdio.bp.cyaninc.com dist tests/e2e",
     "local-e2e-test": "wdio-client remote_e2e_test localhost:3000 dist tests/e2e",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "npm run build && node ./bin/www.js",
     "lint": "eslint *.js bin public test routes src spec testUtils handlers && npm run lint-sass",
     "jasmine": "JASMINE_CONFIG_PATH=spec/support/jasmine.json istanbul cover --dir coverage-backend jasmine",
-    "test": "npm run lint && npm run ember-test && npm run jasmine && npm run b2e-test && npm run combine-coverage",
+    "test": "npm run lint && npm run ember-test && npm run jasmine && npm run b2e-test",
     "ember-test": "COVERAGE=true ember test",
     "e2e-test": "wdio-client remote_e2e_test wdio.bp.cyaninc.com dist tests/e2e",
     "local-e2e-test": "wdio-client remote_e2e_test localhost:3000 dist tests/e2e",

--- a/routes/ip.js
+++ b/routes/ip.js
@@ -24,7 +24,7 @@ router.use(methodOverride(function (req, res) {
 router.use(multer({
   dest: path.join(__dirname, '..', 'uploads'),
   rename: function (fieldname, filename) {
-    return filename + '.' + Date.now()
+    return filename + process.env['MASTER'] ? '.' + Date.now() : ''
   },
   onFileUploadStart: function () {
     debug('client request is starting ...')

--- a/routes/ip.js
+++ b/routes/ip.js
@@ -24,7 +24,7 @@ router.use(methodOverride(function (req, res) {
 router.use(multer({
   dest: path.join(__dirname, '..', 'uploads'),
   rename: function (fieldname, filename) {
-    return filename + process.env['MASTER'] ? '.' + Date.now() : ''
+    return filename + process.env['MASTER'] === 'true' ? '.' + Date.now() : ''
   },
   onFileUploadStart: function () {
     debug('client request is starting ...')
@@ -35,6 +35,7 @@ router.use(multer({
 }))
 
 // This will be accessible from base_url/
+IPHandler.init()
 router.route('/')
     .post(IPHandler.post.bind(IPHandler))
 

--- a/spec/ip-spec.js
+++ b/spec/ip-spec.js
@@ -1,4 +1,5 @@
 'use strict'
+process.env['MASTER'] = true
 
 const DeveloperHandler = require('../handlers/developers-handler.js')
 const IPHandler = require('../handlers/ip-handler.js')
@@ -130,7 +131,7 @@ describe('IP Handling Spec', function () {
     })
   })
 
-  describe('post()', function () {
+  describe('post() and checkUsername()', function () {
     let req, res
     beforeEach(function () {
       res = jasmine.createSpyObj('res', ['send', 'end'])
@@ -153,30 +154,17 @@ describe('IP Handling Spec', function () {
           spyOn(DeveloperHandler, 'get').and.callFake(function () {
             return Promise.resolve()
           })
-        })
-        it('should start the tests', function (done) {
           IPHandler.post(req, res)
-          .then(() => {
-            expect(IPHandler.startTest).toHaveBeenCalledWith(req, res)
-            done()
-          })
-          .catch((err) => {
-            done.fail(err)
-          })
         })
-        it('should call DeveloperHandler.get with the correct parameters', function (done) {
-          IPHandler.post(req, res)
-          .then(() => {
-            expect(DeveloperHandler.get).toHaveBeenCalledWith({
-              query: {
-                username: req.headers.username,
-                token: req.headers.token
-              }
-            })
-            done()
-          })
-          .catch((err) => {
-            done.fail(err)
+        it('should start the tests', function () {
+          expect(IPHandler.startTest).toHaveBeenCalledWith(req, res)
+        })
+        it('should call DeveloperHandler.get with the correct parameters', function () {
+          expect(DeveloperHandler.get).toHaveBeenCalledWith({
+            query: {
+              username: req.headers.username,
+              token: req.headers.token
+            }
           })
         })
       })
@@ -185,17 +173,11 @@ describe('IP Handling Spec', function () {
           spyOn(DeveloperHandler, 'get').and.callFake(function () {
             return Promise.reject('Error')
           })
-        })
-        it('should send the error back in the res object', function (done) {
           IPHandler.post(req, res)
-          .then((err) => {
-            done.fail(err)
-          })
-          .catch(() => {
-            expect(res.send).toHaveBeenCalledWith('Error')
-            expect(res.end).toHaveBeenCalled()
-            done()
-          })
+        })
+        it('should send the error back in the res object', function () {
+          expect(res.send).toHaveBeenCalledWith('Error')
+          expect(res.end).toHaveBeenCalled()
         })
       })
       describe('username or token does not exist', function () {
@@ -206,17 +188,11 @@ describe('IP Handling Spec', function () {
               token: '~'
             }
           }
-        })
-        it('should send an error in the res object', function (done) {
           IPHandler.post(req, res)
-          .then((err) => {
-            done.fail(err)
-          })
-          .catch(() => {
-            expect(res.send).toHaveBeenCalled()
-            expect(res.end).toHaveBeenCalled()
-            done()
-          })
+        })
+        it('should send an error in the res object', function () {
+          expect(res.send).toHaveBeenCalled()
+          expect(res.end).toHaveBeenCalled()
         })
       })
     })
@@ -232,16 +208,10 @@ describe('IP Handling Spec', function () {
         spyOn(IPHandler, 'checkIP').and.callFake(function () {
           return Promise.resolve(true)
         })
-      })
-      it('should start the tests', function (done) {
         IPHandler.post(req, res)
-        .then(() => {
-          expect(IPHandler.startTest).toHaveBeenCalledWith(req, res)
-          done()
-        })
-        .catch((err) => {
-          done.fail(err)
-        })
+      })
+      it('should start the tests', function () {
+        expect(IPHandler.startTest).toHaveBeenCalledWith(req, res)
       })
     })
     describe('checkIP rejects', function () {
@@ -252,37 +222,24 @@ describe('IP Handling Spec', function () {
             token: '123456'
           }
         }
-        spyOn(IPHandler, 'startTest')
         spyOn(IPHandler, 'checkIP').and.callFake(function () {
           return Promise.reject('Error')
         })
-      })
-      it('should send an error message in the res object', function (done) {
         IPHandler.post(req, res)
-        .then((err) => {
-          done.fail(err)
-        })
-        .catch((result) => {
-          expect(res.send).toHaveBeenCalledWith('Error')
-          expect(res.end).toHaveBeenCalled()
-          done()
-        })
+      })
+      it('should send an error message in the res object', function () {
+        expect(res.send).toHaveBeenCalledWith('Error')
+        expect(res.end).toHaveBeenCalled()
       })
     })
     describe('No headers exist', function () {
       beforeEach(function () {
         req = {}
-      })
-      it('should send an error message in the res object', function (done) {
         IPHandler.post(req, res)
-        .then((err) => {
-          done.fail(err)
-        })
-        .catch(() => {
-          expect(res.send).toHaveBeenCalled()
-          expect(res.end).toHaveBeenCalled()
-          done()
-        })
+      })
+      it('should send an error message in the res object', function () {
+        expect(res.send).toHaveBeenCalled()
+        expect(res.end).toHaveBeenCalled()
       })
     })
   })

--- a/spec/ip-spec.js
+++ b/spec/ip-spec.js
@@ -321,7 +321,3 @@ describe('IP Handling Spec', function () {
     })
   })
 })
-
-
-
-

--- a/spec/ip-spec.js
+++ b/spec/ip-spec.js
@@ -1,5 +1,4 @@
 'use strict'
-process.env['MASTER'] = true
 
 const DeveloperHandler = require('../handlers/developers-handler.js')
 const IPHandler = require('../handlers/ip-handler.js')
@@ -23,12 +22,13 @@ describe('IP Handling Spec', function () {
       res = {}
       spyOn(processUpload, 'newFile').and.callFake(function () {
       })
+      IPHandler.MASTER = true
       IPHandler.startTest(req, res)
     })
 
     it('should call processUpload.newFile() with the correct arguments', function () {
       expect(processUpload.newFile).toHaveBeenCalledWith(
-        req.files.tarball.name, req.body['entry-point'], req.body['tests-folder'], res)
+        req.files.tarball.name, req.body['entry-point'], req.body['tests-folder'], res, true)
     })
   })
 
@@ -131,10 +131,18 @@ describe('IP Handling Spec', function () {
     })
   })
 
-  describe('post() and checkUsername()', function () {
+  describe('post()', function () {
     let req, res
     beforeEach(function () {
       res = jasmine.createSpyObj('res', ['send', 'end'])
+    })
+    it('should start the tests if the server is a slave', function (done) {
+      IPHandler.MASTER = false
+      spyOn(IPHandler, 'startTest')
+      IPHandler.post(req, res).then(() => {
+        expect(IPHandler.startTest).toHaveBeenCalled()
+        done()
+      })
     })
     describe('Check IP resolves to false', function () {
       beforeEach(function () {
@@ -144,55 +152,23 @@ describe('IP Handling Spec', function () {
             token: '123456'
           }
         }
+        IPHandler.MASTER = true
         spyOn(IPHandler, 'startTest')
         spyOn(IPHandler, 'checkIP').and.callFake(function () {
           return Promise.resolve(false)
         })
       })
-      describe('DeveloperHandler.get should resolve', function () {
+      describe('checkUsername() resolves', function () {
         beforeEach(function () {
-          spyOn(DeveloperHandler, 'get').and.callFake(function () {
+          spyOn(IPHandler, 'checkUsername').and.callFake(function () {
             return Promise.resolve()
           })
-          IPHandler.post(req, res)
         })
-        it('should start the tests', function () {
-          expect(IPHandler.startTest).toHaveBeenCalledWith(req, res)
-        })
-        it('should call DeveloperHandler.get with the correct parameters', function () {
-          expect(DeveloperHandler.get).toHaveBeenCalledWith({
-            query: {
-              username: req.headers.username,
-              token: req.headers.token
-            }
+        it('should call checkUsername()', function (done) {
+          IPHandler.post(req, res).then(() => {
+            expect(IPHandler.checkUsername).toHaveBeenCalled()
+            done()
           })
-        })
-      })
-      describe('DeveloperHandler.get rejects', function () {
-        beforeEach(function () {
-          spyOn(DeveloperHandler, 'get').and.callFake(function () {
-            return Promise.reject('Error')
-          })
-          IPHandler.post(req, res)
-        })
-        it('should send the error back in the res object', function () {
-          expect(res.send).toHaveBeenCalledWith('Error')
-          expect(res.end).toHaveBeenCalled()
-        })
-      })
-      describe('username or token does not exist', function () {
-        beforeEach(function () {
-          req = {
-            query: {
-              username: '',
-              token: '~'
-            }
-          }
-          IPHandler.post(req, res)
-        })
-        it('should send an error in the res object', function () {
-          expect(res.send).toHaveBeenCalled()
-          expect(res.end).toHaveBeenCalled()
         })
       })
     })
@@ -204,14 +180,17 @@ describe('IP Handling Spec', function () {
             token: '123456'
           }
         }
+        IPHandler.MASTER = true
         spyOn(IPHandler, 'startTest')
         spyOn(IPHandler, 'checkIP').and.callFake(function () {
           return Promise.resolve(true)
         })
-        IPHandler.post(req, res)
       })
-      it('should start the tests', function () {
-        expect(IPHandler.startTest).toHaveBeenCalledWith(req, res)
+      it('should start the tests', function (done) {
+        IPHandler.post(req, res).then(() => {
+          expect(IPHandler.startTest).toHaveBeenCalled()
+          done()
+        })
       })
     })
     describe('checkIP rejects', function () {
@@ -225,11 +204,17 @@ describe('IP Handling Spec', function () {
         spyOn(IPHandler, 'checkIP').and.callFake(function () {
           return Promise.reject('Error')
         })
-        IPHandler.post(req, res)
       })
-      it('should send an error message in the res object', function () {
-        expect(res.send).toHaveBeenCalledWith('Error')
-        expect(res.end).toHaveBeenCalled()
+      it('should send an error message in the res object', function (done) {
+        IPHandler.post(req, res).then(() => {
+          done.fail()
+        })
+        .catch((result) => {
+          expect(result).toEqual('Error')
+          expect(res.send).toHaveBeenCalledWith('Error')
+          expect(res.end).toHaveBeenCalled()
+          done()
+        })
       })
     })
     describe('No headers exist', function () {
@@ -237,10 +222,106 @@ describe('IP Handling Spec', function () {
         req = {}
         IPHandler.post(req, res)
       })
-      it('should send an error message in the res object', function () {
-        expect(res.send).toHaveBeenCalled()
-        expect(res.end).toHaveBeenCalled()
+      it('should send an error message in the res object', function (done) {
+        IPHandler.post(req, res).then(() => {
+          done.fail()
+        })
+        .catch((result) => {
+          expect(result).toEqual('Error: Headers do not exist')
+          expect(res.send).toHaveBeenCalledWith('Error: Headers do not exist')
+          expect(res.end).toHaveBeenCalled()
+          done()
+        })
+      })
+    })
+  })
+  describe('checkUsername()', function () {
+    let req, res
+    beforeEach(function () {
+      res = jasmine.createSpyObj('res', ['send', 'end'])
+      spyOn(IPHandler, 'startTest')
+    })
+    describe('username or token does not exist', function () {
+      beforeEach(function () {
+        req = {
+          headers: {
+            username: '',
+            token: '~'
+          }
+        }
+      })
+      it('should send an error in the res object', function (done) {
+        IPHandler.checkUsername(req, res).then((err) => {
+          done.fail(err)
+        })
+        .catch(() => {
+          expect(res.send).toHaveBeenCalled()
+          expect(res.end).toHaveBeenCalled()
+          done()
+        })
+      })
+    })
+
+    describe('DeveloperHandler.get should resolve', function () {
+      beforeEach(function () {
+        req = {
+          headers: {
+            username: 'test-user',
+            token: '123456'
+          }
+        }
+        spyOn(DeveloperHandler, 'get').and.callFake(function () {
+          return Promise.resolve()
+        })
+      })
+      it('should start the tests', function (done) {
+        IPHandler.checkUsername(req, res).then(() => {
+          expect(IPHandler.startTest).toHaveBeenCalledWith(req, res)
+          done()
+        })
+      })
+      it('should call DeveloperHandler.get with the correct parameters', function (done) {
+        IPHandler.checkUsername(req, res).then(() => {
+          expect(DeveloperHandler.get).toHaveBeenCalledWith({
+            query: {
+              username: req.headers.username,
+              token: req.headers.token
+            }
+          })
+          done()
+        })
+        .catch((err) => {
+          done.fail(err)
+        })
+      })
+    })
+    describe('DeveloperHandler.get rejects', function () {
+      beforeEach(function () {
+        req = {
+          headers: {
+            username: 'test-user',
+            token: '123456'
+          }
+        }
+        spyOn(DeveloperHandler, 'get').and.callFake(function () {
+          return Promise.reject('Error')
+        })
+      })
+      it('should send the error back in the res object', function (done) {
+        IPHandler.checkUsername(req, res).then((err) => {
+          done.fail(err)
+        })
+        .catch((result) => {
+          expect(result).toEqual('Error')
+          expect(res.send).toHaveBeenCalledWith('Error')
+          expect(res.end).toHaveBeenCalled()
+          done()
+        })
       })
     })
   })
 })
+
+
+
+

--- a/spec/process-upload-spec.js
+++ b/spec/process-upload-spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-nested-callbacks */
 
 'use strict'
-
+process.env['MASTER'] = false
 const childProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')

--- a/spec/process-upload-spec.js
+++ b/spec/process-upload-spec.js
@@ -26,9 +26,7 @@ describe('process-upload', function () {
     beforeEach(function () {
       res = jasmine.createSpyObj('res', ['send', 'end'])
       seconds = Math.floor(new Date().getTime() / 1000)
-      console.log('attempting newFile call...')
       processUpload.newFile('filename', 'entry-point', '.', res)
-      console.log('done----------------------')
     })
 
     it('spawns a new process', function () {

--- a/spec/process-upload-spec.js
+++ b/spec/process-upload-spec.js
@@ -1,7 +1,6 @@
 /* eslint-disable max-nested-callbacks */
 
 'use strict'
-process.env['MASTER'] = false
 const childProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
@@ -69,11 +68,11 @@ describe('process-upload', function () {
 
       it('writes a file', function () {
         expect(fs.writeFile).toHaveBeenCalledWith(
-          path.join(__dirname, '../screenshots/output-' + seconds + '.json'),
+          path.join(__dirname, '../screenshots/output-' + seconds + '-..json'),
           JSON.stringify({
             exitCode: 13,
             info: 'some-stdout-datasome-stderr-data',
-            output: 'screenshots/' + seconds + '.tar'
+            output: 'screenshots/' + seconds + '-..tar'
           }),
           jasmine.any(Function)
         )

--- a/spec/webdriverio-spec.js
+++ b/spec/webdriverio-spec.js
@@ -1,0 +1,153 @@
+'use strict'
+
+const wdioTester = require('../src/webdriverioTester')
+const fs = require('fs-extra')
+const path = require('path')
+
+describe('WebDriverIO Testing Spec', function () {
+  describe('init()', function () {
+    let res
+    beforeEach(function () {
+      res = wdioTester.init()
+    })
+    it('should initialize this.exec', function () {
+      expect(wdioTester.exec).toBeDefined()
+    })
+    it('should initialize running processes to a new map', function () {
+      expect(wdioTester.runningProcesses).toEqual(new Map())
+    })
+    it('should return this', function () {
+      expect(wdioTester).toEqual(res)
+    })
+  })
+  describe('getExisting()', function () {
+    let id, result
+    beforeEach(function () {
+      id = 1234
+      wdioTester.runningProcesses = new Map()
+      wdioTester.runningProcesses.set(id, [{
+        server: 'localhost:3000',
+        test: 'test-e2e',
+        timestamp: '4350283445254',
+        testComplete: false
+      },
+      {
+        server: 'localhost:4000',
+        test: 'test2-e2e',
+        timestamp: '4350282343445254',
+        testComplete: true
+      }])
+      spyOn(wdioTester, 'exec').and.callFake(function () {
+        return Promise.resolve(['found'])
+      })
+      result = wdioTester.getExisting(id)
+    })
+    it('should run the exec command test twice', function () {
+      expect(wdioTester.exec.calls.count()).toEqual(2)
+    })
+    it('should call the exec command with the correct curl commands', function () {
+      let curl = 'curl -s localhost:3000/status/4350283445254-test-e2e'
+      expect(wdioTester.exec.calls.first().args[0]).toEqual(curl)
+      curl = 'curl -s localhost:4000/status/4350282343445254-test2-e2e'
+      expect(wdioTester.exec.calls.mostRecent().args[0]).toEqual(curl)
+    })
+    it('should return that all the tests are complete', function (done) {
+      result.then((res) => {
+        expect(res).toBe(true)
+        done()
+      })
+    })
+  })
+  describe('combineScreenshots()', function () {
+    let timestamp, tarFiles
+    beforeEach(function () {
+      timestamp = '23098409'
+      tarFiles = ['tmp/23098409-tests2-e2e.tar', 'tmp/23098409-tests-e2e.tar']
+      spyOn(fs, 'ensureDirSync')
+    })
+    describe('First exec resolves, second exec resolves', function () {
+      beforeEach(function () {
+        spyOn(wdioTester, 'exec').and.callFake(function (cmd) {
+          return Promise.resolve()
+        })
+      })
+      it('should call the exec command with the correct curl commands', function (done) {
+        wdioTester.combineScreenshots(tarFiles, '23098409').then(() => {
+          expect(wdioTester.exec.calls.allArgs()).toEqual([
+            [`bash ${path.join(__dirname, '../src', 'tarScreenshots.sh')} 23098409-tests2-e2e.tar ${timestamp} tests2-e2e`],
+            [`bash ${path.join(__dirname, '../src', 'tarScreenshots.sh')} 23098409-tests-e2e.tar ${timestamp} tests-e2e`],
+            [`tar -cf ${timestamp}.tar build-${timestamp}/screenshots/*`],
+            [`mv ${timestamp}.tar screenshots/`]
+          ])
+          done()
+        })
+      })
+    })
+    describe('First exec fails', function () {
+      beforeEach(function () {
+        spyOn(wdioTester, 'exec').and.callFake(function (cmd) {
+          return Promise.reject('Error')
+        })
+      })
+      it('should reject with an error', function (done) {
+        wdioTester.combineScreenshots(tarFiles, timestamp).then(() => {
+          done.fail()
+        })
+        .catch((err) => {
+          expect(err).toEqual('Error')
+          done()
+        })
+      })
+    })
+    describe('First exec resolves, Second exec fails', function () {
+      beforeEach(function () {
+        spyOn(wdioTester, 'exec').and.callFake(function (cmd) {
+          if (cmd.startsWith('tar')) {
+            return Promise.resolve()
+          } else if (cmd.startsWith('mv')) {
+            return Promise.reject('Error2')
+          }
+        })
+        it('should reject with an error', function (done) {
+          wdioTester.combineScreenshots(tarFiles, timestamp).then(() => {
+            done.fail()
+          })
+          .catch((err) => {
+            expect(err).toEqual('Error2')
+            done()
+          })
+        })
+      })
+    })
+  })
+  describe('combineResults()', function () {
+    
+  })
+  describe('submitTarball()', function () {
+
+  })
+  describe('submitTarballs()', function () {
+
+  })
+  describe('getResults()', function () {
+
+  })
+  describe('getTarball()', function () {
+    
+  })
+  describe('processResults()', function () {
+
+  })
+  describe('checkServer()', function () {
+
+  })
+  describe('checkServerAvailibility()', function () {
+
+  })
+  describe('getRandomServer()', function () {
+
+  })
+  describe('execute()', function () {
+
+  })
+})

--- a/spec/webdriverio-spec.js
+++ b/spec/webdriverio-spec.js
@@ -76,8 +76,8 @@ describe('WebDriverIO Testing Spec', function () {
       it('should call the exec command with the correct curl commands', function (done) {
         wdioTester.combineScreenshots(tarFiles, '23098409').then(() => {
           expect(wdioTester.exec.calls.allArgs()).toEqual([
-            [`bash ${path.join(__dirname, '../src', 'tarScreenshots.sh')} 23098409-tests2-e2e.tar ${timestamp} tests2-e2e`],
-            [`bash ${path.join(__dirname, '../src', 'tarScreenshots.sh')} 23098409-tests-e2e.tar ${timestamp} tests-e2e`],
+            [`bash ${path.join(__dirname, '../src', 'tarScreenshots.sh')} 23098409-tests2-e2e.tar ${timestamp} tests2-e2e`], // eslint-disable-line max-len
+            [`bash ${path.join(__dirname, '../src', 'tarScreenshots.sh')} 23098409-tests-e2e.tar ${timestamp} tests-e2e`], // eslint-disable-line max-len
             [`tar -cf ${timestamp}.tar build-${timestamp}/screenshots/*`],
             [`mv ${timestamp}.tar screenshots/`]
           ])
@@ -469,7 +469,8 @@ describe('WebDriverIO Testing Spec', function () {
       })
       it('should be called with the correct arguments', function (done) {
         wdioTester.execute(filename, entryPoint, seconds, testsFolder).then(() => {
-          expect(wdioTester.submitTarballs).toHaveBeenCalledWith(entryPoint, seconds, testsFolder + '/tmp', serversArray)
+          expect(wdioTester.submitTarballs)
+            .toHaveBeenCalledWith(entryPoint, seconds, testsFolder + '/tmp', serversArray)
           done()
         })
       })

--- a/spec/webdriverio-spec.js
+++ b/spec/webdriverio-spec.js
@@ -410,7 +410,7 @@ describe('WebDriverIO Testing Spec', function () {
     let serverArray = ['localhost:3000', 'localhost:3500', 'localhost:4000']
     it('should return one of the servers from the given server array parameter', function () {
       let res = wdioTester.getRandomServer(serverArray)
-      expect(serverArray.includes(res)).toBeTruthy()
+      expect(serverArray.indexOf(res)).not.toEqual(-1)
     })
   })
   describe('execute()', function () {

--- a/spec/webdriverio-spec.js
+++ b/spec/webdriverio-spec.js
@@ -3,6 +3,8 @@
 const wdioTester = require('../src/webdriverioTester')
 const fs = require('fs-extra')
 const path = require('path')
+const childProcess = require('child_process')
+const http = require('http')
 
 describe('WebDriverIO Testing Spec', function () {
   describe('init()', function () {
@@ -121,33 +123,362 @@ describe('WebDriverIO Testing Spec', function () {
     })
   })
   describe('combineResults()', function () {
-    
+    let id, result
+    beforeEach(function () {
+      id = 1234
+      wdioTester.runningProcesses = new Map()
+      wdioTester.runningProcesses.set(id, [{
+        server: 'localhost:3000',
+        test: 'test-e2e',
+        timestamp: '4350283445254',
+        testComplete: false
+      },
+      {
+        server: 'localhost:4000',
+        test: 'test2-e2e',
+        timestamp: '4350282343445254',
+        testComplete: true
+      }])
+      spyOn(wdioTester, 'processResults').and.callFake(function () {
+        return Promise.resolve({
+          exitCode: 1,
+          output: 'build/1091842308410-homepage-e2e.tar',
+          info: 'Information'
+        })
+      })
+      spyOn(fs, 'writeFileSync')
+      result = wdioTester.combineResults(id)
+    })
+    describe('combineScreenshots() resolves', function () {
+      beforeEach(function () {
+        spyOn(wdioTester, 'combineScreenshots').and.callFake(function () {
+          return Promise.resolve()
+        })
+      })
+      it('should call processResults() twice with the correct arguments', function (done) {
+        result.then(() => {
+          let res0 = wdioTester.runningProcesses.get(id)[0]
+          let res1 = wdioTester.runningProcesses.get(id)[1]
+          expect(wdioTester.processResults.calls.allArgs()).toEqual([
+            [res0.timestamp, res0.server, res0.test],
+            [res1.timestamp, res1.server, res1.test]
+          ])
+          done()
+        })
+        .catch((err) => {
+          done.fail(err)
+        })
+      })
+      it('should call combineScreenshots with the correct arguments', function (done) {
+        result.then(() => {
+          expect(wdioTester.combineScreenshots.calls.allArgs()).toEqual([
+            [['build/1091842308410-homepage-e2e.tar', 'build/1091842308410-homepage-e2e.tar'], '1091842308410']
+          ])
+          done()
+        })
+        .catch((err) => {
+          done.fail(err)
+        })
+      })
+    })
   })
   describe('submitTarball()', function () {
-
+    const tarball = 'test.tar'
+    const server = 'localhost:3000'
+    const test = 'test-e2e'
+    const entryPoint = 'dist/'
+    const timestamp1 = '4097509'
+    describe('Child process returns an error', function () {
+      beforeEach(function () {
+        spyOn(childProcess, 'exec').and.callFake(function (cmd, cb) {
+          cb('Error', null, null)
+        })
+      })
+      it('should be rejected', function (done) {
+        wdioTester.submitTarball(tarball, server, test, entryPoint, timestamp1).then((err) => {
+          done.fail(err)
+        })
+        .catch((res) => {
+          expect(res).toEqual('Error')
+          done()
+        })
+      })
+    })
+    describe('should not fail with an error', function () {
+      beforeEach(function () {
+        spyOn(childProcess, 'exec').and.callFake(function (cmd, cb) {
+          cb(null, '820398080', null)
+        })
+        wdioTester.runningProcesses.set(timestamp1, [
+          'something'
+        ])
+      })
+      afterEach(function () {
+        wdioTester.runningProcesses = new Map()
+      })
+      it('should add the new running process to the map with the passed in timestamp', function (done) {
+        wdioTester.submitTarball(tarball, server, test, entryPoint, timestamp1).then((timestamp) => {
+          expect(wdioTester.runningProcesses.get(timestamp).length).toEqual(2)
+          expect(wdioTester.runningProcesses.get(timestamp)[1].timestamp).toEqual('820398080')
+          done()
+        })
+      })
+      it('should return the same timestamp passed in', function (done) {
+        wdioTester.submitTarball(tarball, server, test, entryPoint, timestamp1).then((timestamp) => {
+          expect(timestamp).toEqual(timestamp1)
+          done()
+        })
+      })
+    })
   })
   describe('submitTarballs()', function () {
-
+    const servers = ['localhost:3000', 'localhost:4000']
+    const testsFolder = 'tests/e2e/'
+    const entryPoint = 'dist/'
+    const timestamp = '3120948'
+    beforeEach(function () {
+      spyOn(fs, 'statSync').and.callFake(function () {
+        return {
+          isFile: function () {
+            return true
+          }
+        }
+      })
+      spyOn(fs, 'readdirSync').and.callFake(function () {
+        return [
+          'test1.tar',
+          'test2.tar',
+          'test3.tar'
+        ]
+      })
+      spyOn(fs, 'rename')
+      spyOn(wdioTester, 'submitTarball').and.callFake(function () {
+        return Promise.resolve('82304982')
+      })
+      spyOn(wdioTester, 'getRandomServer').and.callFake(function () {
+        return servers[0]
+      })
+    })
+    it('should call getRandomServer() thrice with the correct arguments', function (done) {
+      wdioTester.submitTarballs(entryPoint, timestamp, testsFolder, servers).then((timestampReturned) => {
+        expect(wdioTester.getRandomServer.calls.allArgs()).toEqual([
+          [servers], [servers], [servers]
+        ])
+        done()
+      })
+    })
+    it('should return the correct timestamp', function (done) {
+      wdioTester.submitTarballs(entryPoint, timestamp, testsFolder, servers).then((timestampReturned) => {
+        expect(timestampReturned).toEqual(timestamp)
+        done()
+      })
+    })
+    it('should call submit tarballs thrice with the correct arguments', function (done) {
+      wdioTester.submitTarballs(entryPoint, timestamp, testsFolder, servers).then((timestampReturned) => {
+        expect(wdioTester.submitTarball.calls.allArgs()).toEqual([
+          ['test1-3120948.tar', servers[0], 'test1', entryPoint, timestamp],
+          ['test2-3120948.tar', servers[0], 'test2', entryPoint, timestamp],
+          ['test3-3120948.tar', servers[0], 'test3', entryPoint, timestamp]
+        ])
+        done()
+      })
+    })
   })
   describe('getResults()', function () {
-
+    beforeEach(function () {
+      spyOn(wdioTester, 'exec').and.callFake(function () {
+        return Promise.resolve(['{"args": "check"}'])
+      })
+      it('should return the correct object', function (done) {
+        wdioTester.getResults('localhost:4000/status/30948092').then((obj) => {
+          expect(obj).toEqual({args: 'check'})
+          done()
+        })
+      })
+      it('should call exec with the correct arguments', function (done) {
+        wdioTester.getResults('localhost:4000/status/30948092').then((obj) => {
+          expect(wdioTester.exec.calls.first().args).toEqual('curl -s localhost:4000/status/30948092')
+          done()
+        })
+      })
+    })
   })
   describe('getTarball()', function () {
-    
+    beforeEach(function () {
+      spyOn(wdioTester, 'exec').and.callFake(function () {
+        return Promise.resolve()
+      })
+    })
+    it('should call exec with the correct arguments', function (done) {
+      wdioTester.getTarball('localhost:4000/status/30948092').then(() => {
+        expect(wdioTester.exec.calls.first().args).toEqual(['curl -s -O localhost:4000/status/30948092'])
+        done()
+      })
+    })
   })
   describe('processResults()', function () {
-
+    let timestamp = '102385'
+    let server = 'localhost:3000'
+    let testsDir = 'tmp/'
+    beforeEach(function () {
+      spyOn(wdioTester, 'getResults').and.callFake(function () {
+        return Promise.resolve({
+          output: 'output.tar'
+        })
+      })
+      spyOn(wdioTester, 'getTarball').and.callFake(function () {
+        return Promise.resolve()
+      })
+    })
+    it('should resolve both times and return the results', function (done) {
+      wdioTester.processResults(timestamp, server, testsDir).then((results) => {
+        expect(results).toEqual({
+          output: 'output.tar'
+        })
+        done()
+      })
+    })
+    it('should call getResults() with the correct arguments', function (done) {
+      const url = server + '/screenshots/output-' + timestamp + '-' + testsDir + '.json'
+      wdioTester.processResults(timestamp, server, testsDir).then((results) => {
+        expect(wdioTester.getResults).toHaveBeenCalledWith(url)
+        done()
+      })
+    })
+    it('should call getTarball() with the correct arguments', function (done) {
+      const url = server + '/output.tar'
+      wdioTester.processResults(timestamp, server, testsDir).then((results) => {
+        expect(wdioTester.getTarball).toHaveBeenCalledWith(url)
+        done()
+      })
+    })
   })
   describe('checkServer()', function () {
-
+    beforeEach(function () {
+      spyOn(http, 'get').and.callFake(function (args, cb) {
+        cb()
+      })
+    })
+    it('should split the server name correctly and return that it is availible', function (done) {
+      wdioTester.checkServer('localhost:3000').then((server) => {
+        expect(http.get.calls.first().args).toEqual([
+          {
+            host: 'localhost',
+            port: '3000'
+          },
+          jasmine.any(Function)
+        ])
+        done()
+      })
+    })
+    it('should return that it is availible', function (done) {
+      wdioTester.checkServer('localhost:3000').then((server) => {
+        expect(server).toEqual('localhost:3000')
+        done()
+      })
+    })
   })
   describe('checkServerAvailibility()', function () {
-
+    beforeEach(function () {
+      spyOn(fs, 'readFileSync').and.callFake(function () {
+        return '{"potentialServers": ["localhost:3000", "localhost:4000"]}'
+      })
+      spyOn(wdioTester, 'checkServer').and.callFake(function () {
+        return Promise.resolve('localhost:3000')
+      })
+    })
+    it('should call checkServer() twice with the correct arguments', function (done) {
+      wdioTester.checkServerAvailibility().then(() => {
+        expect(wdioTester.checkServer.calls.allArgs()).toEqual([
+          ['localhost:3000'],
+          ['localhost:4000']
+        ])
+        done()
+      })
+    })
+    it('should return the correct server array', function (done) {
+      wdioTester.checkServerAvailibility().then((servers) => {
+        expect(servers).toEqual([
+          'localhost:3000',
+          'localhost:3000'
+        ])
+        done()
+      })
+    })
   })
   describe('getRandomServer()', function () {
-
+    let serverArray = ['localhost:3000', 'localhost:3500', 'localhost:4000']
+    it('should return one of the servers from the given server array parameter', function () {
+      let res = wdioTester.getRandomServer(serverArray)
+      expect(serverArray.includes(res)).toBeTruthy()
+    })
   })
   describe('execute()', function () {
+    let filename = 'test.tar'
+    let entryPoint = 'dist/'
+    let seconds = '198276734'
+    let testsFolder = 'tests/e2e/'
 
+    describe('childProcess returns an error', function () {
+      beforeEach(function () {
+        spyOn(wdioTester, 'checkServerAvailibility').and.callFake(function () {
+          return Promise.resolve(['localhost:3000', 'localhost:3500', 'localhost:4000'])
+        })
+        spyOn(childProcess, 'exec').and.callFake(function (cmd, cb) {
+          cb('Error', null, null)
+        })
+      })
+      it('should catch the error and reject the promise', function (done) {
+        wdioTester.execute(filename, entryPoint, seconds, testsFolder).then((err) => {
+          done.fail(err)
+        })
+        .catch((res) => {
+          expect(res).toEqual('Error')
+          done()
+        })
+      })
+    })
+    describe('checkServerAvailibility() returns no servers', function () {
+      beforeEach(function () {
+        spyOn(wdioTester, 'checkServerAvailibility').and.callFake(function () {
+          return Promise.resolve([])
+        })
+      })
+      it('should reject with the correct error message', function (done) {
+        wdioTester.execute(filename, entryPoint, seconds, testsFolder).then((err) => {
+          done.fail(err)
+        })
+        .catch((res) => {
+          expect(res).toEqual('There are no servers availible')
+          done()
+        })
+      })
+    })
+    describe('submitTarballs()', function () {
+      let serversArray = ['localhost:3000', 'localhost:3500', 'localhost:4000']
+      beforeEach(function () {
+        spyOn(wdioTester, 'checkServerAvailibility').and.callFake(function () {
+          return Promise.resolve(serversArray)
+        })
+        spyOn(wdioTester, 'submitTarballs').and.callFake(function () {
+          return Promise.resolve('9274987239847')
+        })
+        spyOn(childProcess, 'exec').and.callFake(function (cmd, cb) {
+          cb(null, null, null)
+        })
+      })
+      it('should be called with the correct arguments', function (done) {
+        wdioTester.execute(filename, entryPoint, seconds, testsFolder).then(() => {
+          expect(wdioTester.submitTarballs).toHaveBeenCalledWith(entryPoint, seconds, testsFolder + '/tmp', serversArray)
+          done()
+        })
+      })
+      it('should resolve with the correct timestamp', function (done) {
+        wdioTester.execute(filename, entryPoint, seconds, testsFolder).then((timestamp) => {
+          expect(timestamp).toEqual('9274987239847')
+          done()
+        })
+      })
+    })
   })
 })

--- a/src/app.js
+++ b/src/app.js
@@ -54,6 +54,8 @@ app.use(express.static(path.join(__dirname, '..', '/dist')))
 app.get(/^\/status\/(\d+)$/, function (req, res) {
   const id = req.params[0]
   const filename = path.join(__dirname, '..', 'screenshots/output-' + id + '.json')
+  // Poll slave servers
+  // Use waitForResults, Check for results, processResults
   fs.exists(filename, function (exists) {
     if (exists) {
       res.status(200).send('finished')

--- a/src/app.js
+++ b/src/app.js
@@ -19,6 +19,8 @@ const developers = require('../routes/developers')
 const auth = require('../routes/auth')
 const ip = require('../routes/ip')
 
+const webdriverioTester = require('./webdriverioTester')
+
 // view engine setup
 app.set('views', path.join(__dirname, 'views'))
 app.set('view engine', 'jade')
@@ -54,8 +56,10 @@ app.use(express.static(path.join(__dirname, '..', '/dist')))
 app.get(/^\/status\/(\d+)$/, function (req, res) {
   const id = req.params[0]
   const filename = path.join(__dirname, '..', 'screenshots/output-' + id + '.json')
-  // Poll slave servers
-  // Use waitForResults, Check for results, processResults
+  // Poll slave servers using the id (timestamp)
+  if (webdriverioTester.getExisting(id)) {
+    webdriverioTester.combineResults(id)
+  }
   fs.exists(filename, function (exists) {
     if (exists) {
       res.status(200).send('finished')

--- a/src/app.js
+++ b/src/app.js
@@ -57,7 +57,7 @@ app.use(express.static(path.join(__dirname, '..', '/dist')))
 app.get(/^\/status\/(\d+)$/, function (req, res) {
   const id = req.params[0]
   const filename = path.join(__dirname, '..', 'screenshots/output-' + id + '.json')
-  // Poll slave servers using the id (timestamp)
+  // Poll slave servers using the id (timestamp) if the server is the master server
   if (MASTER && webdriverioTester.getExisting(id)) {
     webdriverioTester.combineResults(id)
   }

--- a/src/app.js
+++ b/src/app.js
@@ -21,6 +21,7 @@ const auth = require('../routes/auth')
 const ip = require('../routes/ip')
 
 const webdriverioTester = require('./webdriverioTester')
+webdriverioTester.init()
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'))

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const MASTER = true
 const express = require('express')
 const fs = require('fs')
 const path = require('path')
@@ -57,7 +58,7 @@ app.get(/^\/status\/(\d+)$/, function (req, res) {
   const id = req.params[0]
   const filename = path.join(__dirname, '..', 'screenshots/output-' + id + '.json')
   // Poll slave servers using the id (timestamp)
-  if (webdriverioTester.getExisting(id)) {
+  if (MASTER && webdriverioTester.getExisting(id)) {
     webdriverioTester.combineResults(id)
   }
   fs.exists(filename, function (exists) {

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const MASTER = process.env['MASTER']
+const MASTER = process.env['MASTER'] === 'true'
 const express = require('express')
 const fs = require('fs')
 const path = require('path')

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const MASTER = true
+const MASTER = process.env['MASTER']
 const express = require('express')
 const fs = require('fs')
 const path = require('path')

--- a/src/exec.sh
+++ b/src/exec.sh
@@ -105,7 +105,9 @@ ln -s ../testUtils build-${TIMESTAMP}/testUtils
 cd build-${TIMESTAMP} # IN BUILD DIRECTORY =============================
 tar -xzf ../uploads/$TARBALL
 testIt
-tar -cf ../screenshots/${TIMESTAMP}.tar "$TESTS_FOLDER/screenshots"
+mv tests/e2e/screenshots $TESTS_FOLDER/screenshots
+rm -rf tests/e2e
+tar -cf ../screenshots/${TIMESTAMP}-${TESTS_FOLDER}.tar "$TESTS_FOLDER/screenshots"
 
 # CD TO ROOT DIRECTORY ==================================
 cd $DIR/..

--- a/src/exec.sh
+++ b/src/exec.sh
@@ -98,11 +98,11 @@ function testIt {
 # start at the root of the project
 cd $DIR/..
 echo Processing ${TARBALL}...
-mkdir build-${TIMESTAMP}
-ln -s ../build/node_modules build-${TIMESTAMP}/node_modules
-ln -s ../testUtils build-${TIMESTAMP}/testUtils
+mkdir build-${TIMESTAMP}-${TESTS_FOLDER}
+ln -s ../build/node_modules build-${TIMESTAMP}-${TESTS_FOLDER}/node_modules
+ln -s ../testUtils build-${TIMESTAMP}-${TESTS_FOLDER}/testUtils
 
-cd build-${TIMESTAMP} # IN BUILD DIRECTORY =============================
+cd build-${TIMESTAMP}-${TESTS_FOLDER} # IN BUILD DIRECTORY =============================
 tar -xzf ../uploads/$TARBALL
 testIt
 mv tests/e2e/screenshots $TESTS_FOLDER/screenshots
@@ -112,6 +112,6 @@ tar -cf ../screenshots/${TIMESTAMP}-${TESTS_FOLDER}.tar "$TESTS_FOLDER/screensho
 # CD TO ROOT DIRECTORY ==================================
 cd $DIR/..
 
-rm -rf build-${TIMESTAMP}
+rm -rf build-${TIMESTAMP}-${TESTS_FOLDER}
 
 exit $TEST_STATUS

--- a/src/exec.sh
+++ b/src/exec.sh
@@ -103,7 +103,7 @@ ln -s ../build/node_modules build-${TIMESTAMP}-${TESTS_FOLDER}/node_modules
 ln -s ../testUtils build-${TIMESTAMP}-${TESTS_FOLDER}/testUtils
 
 cd build-${TIMESTAMP}-${TESTS_FOLDER} # IN BUILD DIRECTORY =============================
-tar -xzf ../uploads/$TARBALL
+tar -xf ../uploads/$TARBALL
 testIt
 mv tests/e2e/screenshots $TESTS_FOLDER/screenshots
 rm -rf tests/e2e

--- a/src/process-upload.js
+++ b/src/process-upload.js
@@ -1,5 +1,5 @@
 'use strict'
-const MASTER = true
+const MASTER = process.env['MASTER']
 
 const childProcess = require('child_process')
 const debug = require('debug')('server')

--- a/src/process-upload.js
+++ b/src/process-upload.js
@@ -4,6 +4,7 @@ const childProcess = require('child_process')
 const debug = require('debug')('server')
 const path = require('path')
 const fs = require('fs')
+const http = require('http')
 
 const ns = {
   scriptPath: path.join(__dirname, './exec.sh')
@@ -73,6 +74,35 @@ const watchChild = function (child, seconds) {
   })
 }
 
+function checkServer (serversAvailible, server) {
+  return new Promise((resolve, reject) => {
+    let splitServer = server.split(':')
+    http.get({
+      host: splitServer[0],
+      port: splitServer[1] || '3000'
+    }, (res) => {
+      resolve(-1)
+    }).on('error', (e) => {
+      resolve(serversAvailible.indexOf(server))
+    })
+  })
+}
+
+function checkServerAvailibility () {
+  let servers = []
+  try {
+    servers = JSON.parse(fs.readFileSync(path.join(__dirname, 'servers.json'))).potentialServers
+  } catch (e) {
+    throw new Error(e)
+  }
+  let serversAvailible = servers
+  let pset = []
+  servers.forEach((server) => {
+    pset.push(checkServer(serversAvailible, server))
+  })
+  return serversAvailible
+}
+
 /**
  * We have received a request to process a new file
  * spawn a shell process to do all the operations and
@@ -87,6 +117,9 @@ ns.newFile = function (filename, entryPoint, testsFolder, res) {
   const seconds = Math.floor(new Date().getTime() / 1000)
   debug('START: ------------ ' + seconds)
 
+  console.log('Checking avail')
+  let servers = checkServerAvailibility()
+  console.log('Servers availible', servers)
   const child = childProcess.spawn('bash', [this.scriptPath, filename, entryPoint, seconds, testsFolder])
   watchChild(child, seconds)
   res.send(seconds.toString())

--- a/src/process-upload.js
+++ b/src/process-upload.js
@@ -1,5 +1,4 @@
 'use strict'
-const MASTER = process.env['MASTER']
 
 const childProcess = require('child_process')
 const debug = require('debug')('server')
@@ -85,12 +84,13 @@ const watchChild = function (child, seconds, test) {
  * @param {String} entryPoint - the URL to start testing
  * @param {String} testsFolder - the path to the tests folder (tests/e2e)
  * @param {Response} res - the express response object
+ * @param {String} master - Whether the server is a master server or not
  */
-ns.newFile = function (filename, entryPoint, testsFolder, res) {
+ns.newFile = function (filename, entryPoint, testsFolder, res, master) {
   const seconds = Math.floor(new Date().getTime() / 1000)
   debug('START: ------------ ' + seconds)
 
-  if (MASTER) {
+  if (master) {
     webdriverioTester.execute(filename, entryPoint, seconds, testsFolder)
     .then((timestamp) => {
       console.log('Timestamp: ', timestamp)

--- a/src/process-upload.js
+++ b/src/process-upload.js
@@ -94,14 +94,13 @@ ns.newFile = function (filename, entryPoint, testsFolder, res) {
   debug('START: ------------ ' + seconds)
 
   if (serverIsMaster()) {
-    console.log('Master')
     webdriverioTester.init()
     webdriverioTester.execute(filename, entryPoint, seconds, testsFolder).then((timestamp) => {
+      console.log('Timestamp returned: ' + timestamp.toString())
       res.send(timestamp.toString())
       res.end()
     })
   } else {
-    console.log('Tests Folder: ' + testsFolder)
     const child = childProcess.spawn('bash', [this.scriptPath, filename, entryPoint, seconds, testsFolder])
     watchChild(child, seconds, testsFolder)
     res.send(seconds.toString())

--- a/src/process-upload.js
+++ b/src/process-upload.js
@@ -91,10 +91,9 @@ ns.newFile = function (filename, entryPoint, testsFolder, res) {
   debug('START: ------------ ' + seconds)
 
   if (MASTER) {
-    webdriverioTester.init()
     webdriverioTester.execute(filename, entryPoint, seconds, testsFolder)
     .then((timestamp) => {
-      console.log('Timestamp: ', timestamp.toString())
+      console.log('Timestamp: ', timestamp)
       res.send(timestamp.toString())
       res.end()
     })

--- a/src/process-upload.js
+++ b/src/process-upload.js
@@ -1,4 +1,5 @@
 'use strict'
+const MASTER = true
 
 const childProcess = require('child_process')
 const debug = require('debug')('server')
@@ -75,15 +76,11 @@ const watchChild = function (child, seconds, test) {
   })
 }
 
-function serverIsMaster () {
-  return true
-}
-
 /**
  * We have received a request to process a new file
- * spawn a shell process to do all the operations and
- * watch the output of that process. Then bundle up a json
- * response for the requester.
+ * If the server is the master server, we need to tar all of the files and send them to slave servers
+ * and then wait for there return
+ * If the server is a slave server, we spawn a child process to process the files and run the e2e test
  * @param {String} filename - the name of the tar file that was uploaded
  * @param {String} entryPoint - the URL to start testing
  * @param {String} testsFolder - the path to the tests folder (tests/e2e)
@@ -93,12 +90,17 @@ ns.newFile = function (filename, entryPoint, testsFolder, res) {
   const seconds = Math.floor(new Date().getTime() / 1000)
   debug('START: ------------ ' + seconds)
 
-  if (serverIsMaster()) {
+  if (MASTER) {
     webdriverioTester.init()
-    webdriverioTester.execute(filename, entryPoint, seconds, testsFolder).then((timestamp) => {
-      console.log('Timestamp returned: ' + timestamp.toString())
+    webdriverioTester.execute(filename, entryPoint, seconds, testsFolder)
+    .then((timestamp) => {
+      console.log('Timestamp: ', timestamp.toString())
       res.send(timestamp.toString())
       res.end()
+    })
+    .catch((err) => {
+      console.log(err)
+      process.exit(1)
     })
   } else {
     const child = childProcess.spawn('bash', [this.scriptPath, filename, entryPoint, seconds, testsFolder])

--- a/src/servers.json
+++ b/src/servers.json
@@ -1,5 +1,5 @@
 {
   "potentialServers": [
-    "localhost:3000"
+    "localhost:4000"
   ]
 }

--- a/src/servers.json
+++ b/src/servers.json
@@ -1,0 +1,8 @@
+{
+  "potentialServers": [
+    "localhost:3000",
+    "localhost:3500",
+    "wdio.bp.cyaninc.com",
+    "localhost:4000"
+  ]
+}

--- a/src/servers.json
+++ b/src/servers.json
@@ -1,11 +1,5 @@
 {
   "potentialServers": [
-    "wdio.bp.cyaninc.com",
-    "localhost:4000",
-    "localhost:4500",
-    "localhost:5000",
-    "localhost:5500",
-    "localhost:6000",
-    "localhost:6500"
+    "wdio.bp.cyaninc.com"
   ]
 }

--- a/src/servers.json
+++ b/src/servers.json
@@ -1,8 +1,5 @@
 {
   "potentialServers": [
-    "localhost:3000",
-    "localhost:3500",
-    "wdio.bp.cyaninc.com",
-    "localhost:4000"
+    "localhost:3000"
   ]
 }

--- a/src/servers.json
+++ b/src/servers.json
@@ -1,5 +1,11 @@
 {
   "potentialServers": [
-    "localhost:4000"
+    "wdio.bp.cyaninc.com",
+    "localhost:4000",
+    "localhost:4500",
+    "localhost:5000",
+    "localhost:5500",
+    "localhost:6000",
+    "localhost:6500"
   ]
 }

--- a/src/submitCurl.sh
+++ b/src/submitCurl.sh
@@ -21,31 +21,14 @@ set -x
 set -e
 set -u
 
-TARBALL=$1
-ENTRY_POINT=$2
-TIMESTAMP=$3
-TESTS_FOLDER=$4
+TIMESTAMP=$1
+TESTS_FOLDER=$2
+TARBALL=$3
+TEST=$4
+ENTRY_POINT=$5
+SERVER=$6
 
-TEST_CONFIG="$TESTS_FOLDER/test-config.json"
-NODE_SPECS=$TESTS_FOLDER
-
-
-echo '-INPUT VARIABLES---------------'
-echo tarball: $TARBALL
-echo entry-point: $ENTRY_POINT
-echo timestamp: $TIMESTAMP
-echo '-------------------------------'
-
-cd $DIR/..
-echo Processing ${TARBALL}...
-mkdir build-${TIMESTAMP}
-ln -s ../build/node_modules build-${TIMESTAMP}/node_modules
-ln -s ../testUtils build-${TIMESTAMP}/testUtils
-
-cd build-${TIMESTAMP} # IN BUILD DIRECTORY =============================
-tar -xzf ../uploads/$TARBALL
-cd $TESTS_FOLDER
-find . -type d -maxdepth 1 -mindepth 1 -exec cp -r ../../../dist {} \;
-find . -type d -maxdepth 1 -mindepth 1 -exec tar -Pcf {}.tar {} \;
+cd $DIR/../build-${TIMESTAMP}/$TESTS_FOLDER
+curl -s -F "tarball=@${TARBALL}" -F "entry-point=${ENTRY_POINT}" -F "tests-folder=${TEST}" ${SERVER}
 
 exit 0

--- a/src/submitCurl.sh
+++ b/src/submitCurl.sh
@@ -29,6 +29,6 @@ ENTRY_POINT=$5
 SERVER=$6
 
 cd $DIR/../build-${TIMESTAMP}/$TESTS_FOLDER
-curl -s -F "tarball=@${TARBALL}" -F "entry-point=${ENTRY_POINT}" -F "tests-folder=${TEST}" ${SERVER}
+curl -s -F "tarball=@${TARBALL}" -F "entry-point=${TEST}/${ENTRY_POINT}" -F "tests-folder=${TEST}" ${SERVER}
 
 exit 0

--- a/src/tarScreenshots.sh
+++ b/src/tarScreenshots.sh
@@ -1,0 +1,32 @@
+# -----------------------------------------------------------------------
+# -                                Setup                                -
+# -----------------------------------------------------------------------
+
+# =================================================================================================================
+# Begin snippet taken from http://stackoverflow.com/a/246128 to figure out where the script lives
+# =================================================================================================================
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+# =================================================================================================================
+# End snippet from stackoverflow
+# =================================================================================================================
+
+set -x
+set -e
+set -u
+
+TARBALL=$1
+TIMESTAMP=$2
+
+cd $DIR/..
+mv ${TARBALL} build-${TIMESTAMP}/screenshots
+cd build-${TIMESTAMP}/screenshots
+tar -xvf ${TARBALL}
+
+exit 0

--- a/src/tarScreenshots.sh
+++ b/src/tarScreenshots.sh
@@ -23,10 +23,16 @@ set -u
 
 TARBALL=$1
 TIMESTAMP=$2
+DIRNAME=$3
 
 cd $DIR/..
 mv ${TARBALL} build-${TIMESTAMP}/screenshots
 cd build-${TIMESTAMP}/screenshots
 tar -xvf ${TARBALL}
+rm ${TARBALL}
+cd ${DIRNAME}
+rsync -a screenshots/* ../
+cd ..
+rm -rf ${DIRNAME}
 
 exit 0

--- a/src/tardir.sh
+++ b/src/tardir.sh
@@ -46,3 +46,5 @@ cd build-${TIMESTAMP} # IN BUILD DIRECTORY =============================
 tar -xzf ../uploads/$TARBALL
 cd $TESTS_FOLDER
 find . -type d -maxdepth 1 -mindepth 1 -exec tar cf {}.tar {}  \;
+
+exit 0

--- a/src/tardir.sh
+++ b/src/tardir.sh
@@ -1,0 +1,48 @@
+# -----------------------------------------------------------------------
+# -                                Setup                                -
+# -----------------------------------------------------------------------
+
+# =================================================================================================================
+# Begin snippet taken from http://stackoverflow.com/a/246128 to figure out where the script lives
+# =================================================================================================================
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+# =================================================================================================================
+# End snippet from stackoverflow
+# =================================================================================================================
+
+set -x
+set -e
+set -u
+
+TARBALL=$1
+ENTRY_POINT=$2
+TIMESTAMP=$3
+TESTS_FOLDER=$4
+
+TEST_CONFIG="$TESTS_FOLDER/test-config.json"
+NODE_SPECS=$TESTS_FOLDER
+
+
+echo '-INPUT VARIABLES---------------'
+echo tarball: $TARBALL
+echo entry-point: $ENTRY_POINT
+echo timestamp: $TIMESTAMP
+echo '-------------------------------'
+
+cd $DIR/..
+echo Processing ${TARBALL}...
+mkdir build-${TIMESTAMP}
+ln -s ../build/node_modules build-${TIMESTAMP}/node_modules
+ln -s ../testUtils build-${TIMESTAMP}/testUtils
+
+cd build-${TIMESTAMP} # IN BUILD DIRECTORY =============================
+tar -xzf ../uploads/$TARBALL
+cd $TESTS_FOLDER
+find . -type d -maxdepth 1 -mindepth 1 -exec tar cf {}.tar {}  \;

--- a/src/webdriverioTester.js
+++ b/src/webdriverioTester.js
@@ -128,6 +128,7 @@ const ns = {
     let testsRunning = this.runningProcesses.get(id)
     let pset = []
     testsRunning.forEach((currentTest) => {
+      console.log('Timestamp: ', currentTest.timestamp)
       pset.push(this.processResults(currentTest.timestamp, currentTest.server, currentTest.test))
     })
     return Promise.all(pset)
@@ -182,7 +183,7 @@ const ns = {
     return new Promise((resolve, reject) => {
       console.log(
         `curl -s -F "tarball=@${tarball}" -F "entry-point=${test}/${entryPoint}" -F "tests-folder=${test}" ${server}`)
-      childProcess.exec(
+      return childProcess.exec(
         `bash ${tarpath} ${timestamp1} tests/e2e/tmp ${tarball} ${test} ${entryPoint} ${server}/`,
         (err, stdout, stderr) => {
           if (err) {
@@ -209,6 +210,7 @@ const ns = {
    * @returns {Promise} Resolves with a timestamp or an error
    */
   submitTarballs (entryPoint, timestamp, testsFolder, servers) {
+    console.log('Timestamp tarballs: ', timestamp)
     let pset = []
     let buildPath = path.join(__dirname, '..', 'build-' + timestamp, testsFolder)
     this.runningProcesses.set(timestamp.toString(), [])
@@ -234,22 +236,24 @@ const ns = {
           }
         })
         const server = this.getRandomServer(servers)
-        setTimeout(() => {
-          console.log('Submitting Tarball to ', server)
-          pset.push(this.submitTarball(path.basename(fname), server, element.slice(0, -4), entryPoint, timestamp)
-          .then((timestamp) => {
-          })
-          .catch((err) => {
-            throw new Error(err)
-          }))
-        }, 3000)
+        console.log('Submitting Tarball to ', server)
+        pset.push(this.submitTarball(path.basename(fname), server, element.slice(0, -4), entryPoint, timestamp).then((timestamp2) => {
+          console.log('Timestamp returned: ', timestamp2)
+        })
+        .catch((err) => {
+          console.log('submitTarball fails: ', err)
+          throw new Error(err)
+        }))
       }
     })
     return Promise.all(pset)
     .then((timestampMaybe) => {
+      console.log('Timestamp: ', timestamp)
+      console.log('Timestamp array: ', timestampMaybe)
       return timestamp
     })
     .catch((err) => {
+      console.log('Submit Tarballs fails here: ', err)
       throw new Error(err)
     })
   },
@@ -375,6 +379,7 @@ const ns = {
           }
           return this.submitTarballs(entryPoint, seconds, testsFolder + '/tmp', servers)
           .then((timestamp) => {
+            console.log('Timestamp execute: ', timestamp)
             resolve(timestamp)
           })
           .catch((err) => {

--- a/src/webdriverioTester.js
+++ b/src/webdriverioTester.js
@@ -237,7 +237,8 @@ const ns = {
         })
         const server = this.getRandomServer(servers)
         console.log('Submitting Tarball to ', server)
-        pset.push(this.submitTarball(path.basename(fname), server, element.slice(0, -4), entryPoint, timestamp).then((timestamp2) => {
+        pset.push(this.submitTarball(path.basename(fname), server, element.slice(0, -4), entryPoint, timestamp)
+        .then((timestamp2) => {
           console.log('Timestamp returned: ', timestamp2)
         })
         .catch((err) => {

--- a/src/webdriverioTester.js
+++ b/src/webdriverioTester.js
@@ -63,7 +63,7 @@ const ns = {
         }
       })
       .catch((err) => {
-        throw new Error(err)
+        throw err
       }))
     })
     return Promise.all(pset)
@@ -73,7 +73,7 @@ const ns = {
       })
     })
     .catch((err) => {
-      throw new Error(err)
+      throw err
     })
   },
 

--- a/src/webdriverioTester.js
+++ b/src/webdriverioTester.js
@@ -1,0 +1,273 @@
+#! /usr/bin/env node
+
+/**
+ * @author Adam Meadows [@job13er](https://github.com/job13er)
+ * @copyright 2015 Ciena Corporation. All rights reserved
+ */
+
+'use strict'
+
+/**
+ * @typedef Result
+ * @property {Number} code - the exit code of the command
+ * @property {String} stdout - the standard output from command
+ */
+
+const _ = require('lodash')
+const Q = require('q')
+const path = require('path')
+const exec = require('child_process').exec
+const sleep = require('sleep')
+const http = require('http')
+const fs = require('fs')
+
+/**
+ * Helper for creating a promise (so I don't need to disable new-cap everywhere)
+ * @param {*} resolution - what to resolve the promise with
+ * @returns {Promise} the promise
+ */
+function makePromise (resolution) {
+  return Q(resolution) // eslint-disable-line new-cap
+}
+
+/** @alias tester */
+const ns = {
+  /**
+   * Initialize the module
+   * @returns {tester} the tester instance
+   */
+  init () {
+    // this is on the object for eaiser mocking
+    this.exec = Q.denodeify(exec)
+    return this
+  },
+
+  /**
+   * obvious
+   * @param {String} filename - the filename to remove
+   * @returns {Promise} resolved with result of exec
+   */
+  remove (filename) {
+    return this.exec('rm -rf ' + filename)
+  },
+
+  /**
+   * Submit the tarball for test
+   * @param {String} server - the protocol/host/port of the server
+   * @returns {Promise} resolved when done
+   */
+  submitTarball (server) {
+    console.log('Submitting bundle to ' + server + ' for test...')
+
+    const cmd = [
+      'curl',
+      '-s',
+      '-F',
+      '"tarball=@test.tar.gz"',
+      '-F',
+      '"entry-point=' + process.env['BUILD_OUTPUT_DIR'] + '/"',
+      '-F',
+      '"tests-folder=' + process.env['E2E_TESTS_DIR'] + '"',
+      server + '/'
+    ]
+
+    console.log('Running command: ' + cmd.join(' '))
+
+    return this.exec(cmd.join(' ')).then((res) => {
+      const stdout = res[0]
+      const timestamp = stdout.toString()
+      console.log('TIMESTAMP: ' + timestamp)
+      return timestamp
+    })
+  },
+
+  /**
+   * Wait till the server is done with our tests
+   * @param {String} cmd - the command to execute to check for results
+   * @param {Number} pollInterval - the poll interval in seconds
+   * @returns {Promise} resolved when done
+   */
+  checkForResults (cmd, pollInterval) {
+    console.log('Checking for results...')
+    return this.exec(cmd).then((res) => {
+      const stdout = res[0]
+      if (stdout.toString().toLowerCase() === 'not found') {
+        sleep.sleep(pollInterval)
+        return this.checkForResults(cmd, pollInterval)
+      } else {
+        return makePromise()
+      }
+    })
+  },
+
+  /**
+   * Wait till the server is done with our tests
+   * @param {Object} params - object for named parameters
+   * @param {String} params.timestamp - the timestamp of the results we're waiting for
+   * @param {String} params.server - the protocol/host/port of the server
+   * @param {Number} params.initialSleep - the initial sleep time in seconds
+   * @param {Number} params.pollInterval - the poll interval in seconds
+   * @returns {Promise} resolved when done
+   */
+  waitForResults (params) {
+    console.log('Waiting ' + params.initialSleep + 's before checking')
+    sleep.sleep(params.initialSleep)
+
+    const cmd = 'curl -s ' + params.server + '/status/' + params.timestamp
+    // return this.checkForResults(cmd, params.pollInterval)
+  },
+
+  /**
+   * Fetch the results from the server
+   * @param {String} url - the url to fetch results from
+   * @returns {Promise} resolved when done
+   */
+  getResults (url) {
+    return this.exec('curl -s ' + url).then((res) => {
+      const stdout = res[0]
+      console.log('Parsing results...')
+      const obj = JSON.parse(stdout.toString())
+      return obj
+    })
+  },
+
+  /**
+   * obvious
+   * @param {String} url - the URL to get the tarball from
+   * @returns {Promise} resolved when done
+   */
+  getTarball (url) {
+    return this.exec('curl -s -O ' + url)
+  },
+
+  /**
+   * Obvious
+   * @param {WebdriverioServerTestResults} results - details of the test results
+   * @returns {Promise} resolved when done
+   */
+  extractTarball (results) {
+    const filename = path.basename(results.output)
+    return this.exec('tar -xf ' + filename).then(() => {
+      return {
+        filename: filename,
+        results: results
+      }
+    })
+  },
+
+  /**
+   * Parse and output the results
+   * @param {String} timestamp - the timestamp of the results we're processing
+   * @param {String} server - the protocol/host/port of the server
+   * @param {String} testsDir - The name of the e2e test that we are testing
+   * @returns {Promise} resolved when done
+   */
+  processResults (timestamp, server, testsDir) {
+    const url = server + '/screenshots/output-' + timestamp + '.json'
+
+    return this.getResults(url)
+      .then((results) => {
+        const url = server + '/' + results.output
+        return this.getTarball(url).then(() => {
+          return results
+        })
+      })
+      .then((results) => {
+        return this.extractTarball(results)
+      })
+      .then((params) => {
+        return this.remove(params.filename).then(() => {
+          return params.results
+        })
+      })
+      .then((results) => {
+        console.log(results.info)
+
+        console.log('----------------------------------------------------------------------')
+        console.log('Screenshots directory updated with results from server.')
+
+        // combineResults()
+
+        if (results.exitCode === 0) {
+          console.log('Tests Pass.')
+        } else {
+          console.log('Tests FAILED')
+          process.exit(1)
+        }
+      })
+  },
+
+  checkServer (serversAvailible, server) {
+    return new Promise((resolve, reject) => {
+      let splitServer = server.split(':')
+      http.get({
+        host: splitServer[0],
+        port: splitServer[1] || '3000'
+      }, (res) => {
+        resolve(-1)
+      }).on('error', (e) => {
+        resolve(serversAvailible.indexOf(server))
+      })
+    })
+  },
+
+  checkServerAvailibility () {
+    let servers = []
+    try {
+      servers = JSON.parse(fs.readFileSync(path.join(__dirname, 'servers.json'))).potentialServers
+    } catch (e) {
+      throw new Error(e)
+    }
+    let serversAvailible = servers
+    let pset = []
+    servers.forEach((server) => {
+      pset.push(this.checkServer(serversAvailible, server))
+    })
+    return serversAvailible
+  },
+
+  submitAndWait (argv) {
+    return this.submitTarball(argv.server)
+
+      return this.waitForResults(params).then(() => {
+        return timestamp
+      })
+    })
+    .then((timestamp) => {
+      return this.processResults(timestamp, argv.server)
+    })
+  },
+
+  /**
+   * Actual functionality of the 'webdriverio-test' command
+   * @param {MinimistArgv} argv - the minimist arguments object
+   * @throws CliError
+   */
+  execute (argv) {
+    _.defaults(argv, {
+      initialSleep: 10,
+      pollInterval: 3
+    })
+
+    // Get List of Availible servers here
+    console.log('Checking availibility')
+    let servers = this.checkServerAvailibility()
+    console.log('Servers availible', servers)
+
+    // Execute tardir.sh
+    // This creates a set of tarballs from the tmp directory
+    this.exec('./tardir.sh')
+    .then(() => {
+      // Send a set of tarballs to a set of servers
+      // No need to create the tarballs, just submit each tarball to a different server
+      // For each tarball, run submitAndWait()
+      const tarball = argv
+      this.submitAndWait(tarball).done()
+    })
+    .catch((err) => {
+      console.log(err)
+    })
+  }
+}
+
+module.exports = ns

--- a/src/webdriverioTester.js
+++ b/src/webdriverioTester.js
@@ -161,11 +161,11 @@ const ns = {
         fs.writeFileSync(jsonFile, JSON.stringify(result, null, 2))
       })
       .catch((err) => {
-        throw new Error(err)
+        throw err
       })
     })
     .catch((err) => {
-      throw new Error(err)
+      throw err
     })
   },
 
@@ -218,21 +218,21 @@ const ns = {
     try {
       files = fs.readdirSync(buildPath)
     } catch (err) {
-      throw new Error(err)
+      throw err
     }
     files.forEach((element) => {
       let file
       try {
         file = fs.statSync(path.join(buildPath, element))
       } catch (err) {
-        throw new Error(err)
+        throw err
       }
       if (file.isFile() && element.endsWith('.tar')) {
         let fname = path.join(buildPath, element).slice(0, -4)
         fname = fname + '-' + timestamp + '.tar'
         fs.rename(path.join(buildPath, element), fname, (err) => {
           if (err) {
-            throw new Error(err)
+            throw err
           }
         })
         const server = this.getRandomServer(servers)
@@ -241,15 +241,12 @@ const ns = {
           console.log('Timestamp returned: ', timestamp2)
         })
         .catch((err) => {
-          console.log('submitTarball fails: ', err)
-          throw new Error(err)
+          throw err
         }))
       }
     })
     return Promise.all(pset)
-    .then((timestampMaybe) => {
-      console.log('Timestamp: ', timestamp)
-      console.log('Timestamp array: ', timestampMaybe)
+    .then(() => {
       return timestamp
     })
     .catch((err) => {
@@ -290,7 +287,6 @@ const ns = {
    */
   processResults (timestamp, server, testsDir) {
     const url = server + '/screenshots/output-' + timestamp + '-' + testsDir + '.json'
-
     return this.getResults(url)
       .then((results) => {
         const url = server + '/' + results.output

--- a/src/webdriverioTester.js
+++ b/src/webdriverioTester.js
@@ -55,6 +55,7 @@ const ns = {
      *  {
      *    server: "localhost:4000",
      *    test: "homepage-e2e",
+     *    timestamp: "03498520938",
      *    testComplete: false
      *  }
      * ]
@@ -64,7 +65,11 @@ const ns = {
     testsRunning.forEach((currentTest) => {
       const server = currentTest.server
       const test = currentTest.test
-      const cmd = 'curl -s ' + server + '/status/?id=' + id + '&test=' + test
+      console.log('Curl server: ', server)
+      console.log('Curl test: ', test)
+      console.log('Curl timestamp: ', currentTest.timestamp)
+      const cmd = 'curl -s ' + server + '/status/' + currentTest.timestamp + '-' + test
+      console.log(cmd)
       pset.push(this.exec(cmd).then((res) => {
         const stdout = res[0]
         if (stdout.toString().toLowerCase() === 'not found') {
@@ -75,7 +80,9 @@ const ns = {
       }))
     })
     return Promise.all(pset).then(() => {
-      return testsRunning.reduce((current, element) => current && element.testComplete)
+      return testsRunning.reduce((current, element) => {
+        return current && element.testComplete
+      })
     })
   },
 
@@ -88,7 +95,8 @@ const ns = {
       pset.push(this.processResults(id, server, test))
     })
     Promise.all(pset).then((res) => {
-      return
+      console.log('Final result!: ', res)
+      console.log('This is the place where we need to complete the testing')
     })
   },
 
@@ -200,8 +208,12 @@ const ns = {
     return this.getResults(url)
       .then((results) => {
         const url = server + '/' + results.output
-        return this.getTarball(url).then(() => {
+        return this.getTarball(url)
+        .then(() => {
           return results
+        })
+        .catch((err) => {
+          console.log(err)
         })
       })
   },

--- a/src/webdriverioTester.js
+++ b/src/webdriverioTester.js
@@ -1,8 +1,7 @@
 #! /usr/bin/env node
 
 /**
- * @author Adam Meadows [@job13er](https://github.com/job13er)
- * @copyright 2015 Ciena Corporation. All rights reserved
+ * @author Sam Pastoriza [@pastorsj](https://github.com/pastorsj)
  */
 
 'use strict'
@@ -11,6 +10,15 @@
  * @typedef Result
  * @property {Number} code - the exit code of the command
  * @property {String} stdout - the standard output from command
+ */
+
+/**
+ * This is the object within the array of objects within the map defined in the init function
+ * @typedef {Map of Arrays of Objects} - runningProcesses
+ * @property {String} server - The slave server that a test is running on
+ * @property {String} test - The test currently running on the slave server
+ * @property {String} timestamp - The timestamp tied to that test
+ * @property {Boolean} testComplete - Whether the test is complete on the slave server
  */
 
 const Q = require('q')
@@ -28,8 +36,8 @@ const ns = {
   init () {
     // this is on the object for eaiser mocking
     this.exec = Q.denodeify(childProcess.exec)
-    this.runningProcesses = new Map()
     // This will keep track of the slave servers that are running the e2e tests
+    this.runningProcesses = new Map()
     return this
   },
 
@@ -39,38 +47,42 @@ const ns = {
    * @returns {Boolean} Whether all of the tests are ready
    */
   getExisting (id) {
-    /**
-     * testsRunning => [
-     *  {
-     *    server: "localhost:4000",
-     *    test: "homepage-e2e",
-     *    timestamp: "03498520938",
-     *    testComplete: false
-     *  }
-     * ]
-     */
     let testsRunning = this.runningProcesses.get(id)
     let pset = []
     testsRunning.forEach((currentTest) => {
       const server = currentTest.server
       const test = currentTest.test
       const cmd = 'curl -s ' + server + '/status/' + currentTest.timestamp + '-' + test
-      pset.push(this.exec(cmd).then((res) => {
+      pset.push(this.exec(cmd)
+      .then((res) => {
         const stdout = res[0]
         if (stdout.toString().toLowerCase() === 'not found') {
           currentTest.testComplete = false
         } else {
           currentTest.testComplete = true
         }
+      })
+      .catch((err) => {
+        throw new Error(err)
       }))
     })
-    return Promise.all(pset).then(() => {
+    return Promise.all(pset)
+    .then(() => {
       return testsRunning.reduce((current, element) => {
         return current && element.testComplete
       })
     })
+    .catch((err) => {
+      throw new Error(err)
+    })
   },
 
+  /**
+   * Combines the screenshots returned from the slave servers
+   * @param {Array} tarFiles - The array of tarballs returned from the slave servers
+   * @param {String} timestamp - The timestamp that identifies the set of tests being sent from the client
+   * @returns {Promise} - Indicates whether the screenshots are all complete or there has been an error.
+   */
   combineScreenshots (tarFiles, timestamp) {
     return new Promise((resolve, reject) => {
       try {
@@ -81,33 +93,45 @@ const ns = {
           let dirname = file.slice(file.indexOf('-') + 1, -4)
           pset.push(this.exec(`bash ${path.join(__dirname, 'tarScreenshots.sh')} ${file} ${timestamp} ${dirname}`))
         })
-        return Promise.all(pset).then(() => {
-          this.exec(`tar -cf ${timestamp}.tar build-${timestamp}/screenshots/*`).then(() => {
-            this.exec(`mv ${timestamp}.tar screenshots/`).then(() => {
+        return Promise.all(pset)
+        .then(() => {
+          this.exec(`tar -cf ${timestamp}.tar build-${timestamp}/screenshots/*`)
+          .then(() => {
+            this.exec(`mv ${timestamp}.tar screenshots/`)
+            .then(() => {
               resolve()
             })
+            .catch((err) => {
+              reject(err)
+            })
+          })
+          .catch((err) => {
+            reject(err)
           })
         })
         .catch((err) => {
-          console.log(err)
           reject(err)
         })
-      } catch (e) {
-        console.log(e)
+      } catch (err) {
+        reject(err)
       }
     })
   },
 
+  /**
+   * Combines the results of the tests into a single json file. This file will only indicate whether the tests
+   * pass, not what the screenshots look like.
+   * @param {Number} id - The timestamp identifying the set of tests sent by the client
+   * @returns {Promise} - Will return when the results have been combined or it will error out
+   */
   combineResults (id) {
     let testsRunning = this.runningProcesses.get(id)
     let pset = []
     testsRunning.forEach((currentTest) => {
-      const server = currentTest.server
-      const test = currentTest.test
-      const timestamp = currentTest.timestamp
-      pset.push(this.processResults(timestamp, server, test))
+      pset.push(this.processResults(currentTest.timestamp, currentTest.server, currentTest.test))
     })
-    Promise.all(pset).then((res) => {
+    return Promise.all(pset)
+    .then((res) => {
       let exitCode = 0
       let notZeroCodes = []
       let output = ''
@@ -131,22 +155,33 @@ const ns = {
         info: exitCode === 1 ? notZeroCodes : 'All Tests Passed',
         output
       }
-      this.combineScreenshots(tarFiles, timestamp)
-      let jsonFile = path.join(__dirname, '..', 'screenshots', 'output-' + id + '.json')
-      fs.writeFileSync(jsonFile, JSON.stringify(result, null, 2))
+      return this.combineScreenshots(tarFiles, timestamp).then(() => {
+        let jsonFile = path.join(__dirname, '..', 'screenshots', 'output-' + id + '.json')
+        fs.writeFileSync(jsonFile, JSON.stringify(result, null, 2))
+      })
+      .catch((err) => {
+        throw new Error(err)
+      })
+    })
+    .catch((err) => {
+      throw new Error(err)
     })
   },
 
   /**
    * Submit the tarball for test
    * @param {String} tarball - The path to the tarball
-   * @param {String} server - the protocol/host/port of the server
-   * @param {String} test - the test folder
+   * @param {String} server - The protocol/host/port of the server
+   * @param {String} test - The test folder
+   * @param {String} entryPoint - The directory containing the compiled code (generally the dist directory)
+   * @param {String} timestamp1 - The timestamp associated with the test sent from the master server, not the client
    * @returns {Promise} resolved when done
    */
   submitTarball (tarball, server, test, entryPoint, timestamp1) {
     const tarpath = path.join(__dirname, './submitCurl.sh')
     return new Promise((resolve, reject) => {
+      console.log(
+        `curl -s -F "tarball=@${tarball}" -F "entry-point=${test}/${entryPoint}" -F "tests-folder=${test}" ${server}`)
       childProcess.exec(
         `bash ${tarpath} ${timestamp1} tests/e2e/tmp ${tarball} ${test} ${entryPoint} ${server}/`,
         (err, stdout, stderr) => {
@@ -165,51 +200,60 @@ const ns = {
     })
   },
 
-  submitTarballs (filename, entryPoint, timestamp, testsFolder, servers) {
-    // Go through the testsFolder directory and find all the tar files._
-    // Submit each tarball and wait for the results.
+  /**
+   * Submits a set of tarballs to a set of servers
+   * @param {String} entryPoint - The directory containing the compiled code (generally the dist directory)
+   * @param {String} timestamp - The timestamp identifying the set of tests sent by the client
+   * @param {String} testsFolder - The folder contains all of the tests and tarballs
+   * @param {Array} servers - The avalible servers to send tests to
+   * @returns {Promise} Resolves with a timestamp or an error
+   */
+  submitTarballs (entryPoint, timestamp, testsFolder, servers) {
     let pset = []
     let buildPath = path.join(__dirname, '..', 'build-' + timestamp, testsFolder)
     this.runningProcesses.set(timestamp.toString(), [])
     let files
     try {
       files = fs.readdirSync(buildPath)
-    } catch (e) {
-      console.log(e)
-      process.exit(1)
+    } catch (err) {
+      throw new Error(err)
     }
     files.forEach((element) => {
       let file
       try {
         file = fs.statSync(path.join(buildPath, element))
-      } catch (e) {
-        process.exit(1)
+      } catch (err) {
+        throw new Error(err)
       }
       if (file.isFile() && element.endsWith('.tar')) {
         let fname = path.join(buildPath, element).slice(0, -4)
         fname = fname + '-' + timestamp + '.tar'
         fs.rename(path.join(buildPath, element), fname, (err) => {
           if (err) {
-            console.log(err)
-            process.exit(1)
+            throw new Error(err)
           }
         })
         const server = this.getRandomServer(servers)
-        console.log('Server: ', server)
-        pset.push(this.submitTarball(path.basename(fname), server, element.slice(0, -4), entryPoint, timestamp)
-        .then((timestamp) => {
-        })
-        .catch((err) => {
-          console.log(err)
-          process.exit(1)
-        }))
+        setTimeout(() => {
+          console.log('Submitting Tarball to ', server)
+          pset.push(this.submitTarball(path.basename(fname), server, element.slice(0, -4), entryPoint, timestamp)
+          .then((timestamp) => {
+          })
+          .catch((err) => {
+            throw new Error(err)
+          }))
+        }, 3000)
       }
     })
-    return Promise.all(pset).then((timestampMaybe) => {
-      console.log('Timestamp being returned: ' + timestamp)
+    return Promise.all(pset)
+    .then((timestampMaybe) => {
       return timestamp
     })
+    .catch((err) => {
+      throw new Error(err)
+    })
   },
+
   /**
    * Fetch the results from the server
    * @param {String} url - the url to fetch results from
@@ -219,14 +263,13 @@ const ns = {
     console.log('curl -s ' + url)
     return this.exec('curl -s ' + url).then((res) => {
       const stdout = res[0]
-      console.log('Parsing results...')
       const obj = JSON.parse(stdout.toString())
       return obj
     })
   },
 
   /**
-   * obvious
+   * Gets a tarball from the given url
    * @param {String} url - the URL to get the tarball from
    * @returns {Promise} resolved when done
    */
@@ -252,11 +295,16 @@ const ns = {
           return results
         })
         .catch((err) => {
-          console.log(err)
+          throw new Error(err)
         })
       })
   },
 
+  /**
+   * Uses a get request to determine whether the server is availible
+   * @param {String} server - The given server to checks
+   * @returns {Promise} Resolves with whether the server is availible
+   */
   checkServer (server) {
     return new Promise((resolve, reject) => {
       let splitServer = server.split(':')
@@ -271,40 +319,66 @@ const ns = {
     })
   },
 
+  /**
+   * Checks from a given of servers which servers are availible
+   * @returns {Promise} Resolves with a array of availible servers or throws an error
+   */
   checkServerAvailibility () {
     let servers
     try {
       servers = JSON.parse(fs.readFileSync(path.join(__dirname, 'servers.json'))).potentialServers
     } catch (e) {
-      console.log(e)
       throw new Error(e)
     }
     let pset = []
     servers.map((server) => {
       pset.push(this.checkServer(server))
     })
-    return Promise.all(pset).then((res) => {
+    return Promise.all(pset)
+    .then((res) => {
       return res.filter((s) => {
         return s !== undefined
       })
     })
+    .catch((err) => {
+      throw new Error(err)
+    })
   },
 
+  /**
+   * From an array of servers, it will choose a random server and return it.
+   * @param {Array} servers - A list of potential servers
+   * @returns {String} A server
+   */
   getRandomServer (servers) {
     return servers[Math.floor((Math.random() * servers.length))]
   },
 
+  /**
+   * Executes the test suite by sending each test to a different server in the form of a tarball
+   * @param {String} filename - The name of the incoming tarball containing all of the tests
+   * @param {String} entryPoint - The name of the folder containing the compiled code
+   * @param {String} seconds - The timestamp identifying the set of tests to the client
+   * @param {String} testsFolder - The folder contain the e2e tests (default is tests/e2e)
+   * @returns {Promise} Either returns the timestamp identifying the set of tests to the client or an error
+   */
   execute (filename, entryPoint, seconds, testsFolder) {
     return new Promise((resolve, reject) => {
       this.checkServerAvailibility().then((servers) => {
-        console.log('Servers availible: ' + servers)
+        if (servers.length <= 0) {
+          reject('There are no servers availible')
+        }
         const cmd = ['bash', path.join(__dirname, './tardir.sh'), filename, entryPoint, seconds, testsFolder + '/tmp']
         childProcess.exec(cmd.join(' '), (err, stdout, stderr) => {
           if (err) {
             reject(err)
           }
-          return this.submitTarballs(filename, entryPoint, seconds, testsFolder + '/tmp', servers).then((timestamp) => {
+          return this.submitTarballs(entryPoint, seconds, testsFolder + '/tmp', servers)
+          .then((timestamp) => {
             resolve(timestamp)
+          })
+          .catch((err) => {
+            reject(err)
           })
         })
       })

--- a/tests/e2e/homepage-e2e.js
+++ b/tests/e2e/homepage-e2e.js
@@ -1,4 +1,3 @@
-/* global jQuery */
 'use strict'
 
 const selectors = require('./selectors')
@@ -26,33 +25,6 @@ module.exports = function (ctx) {
       client
         .verifyScreenshots('index.homepage', [ctx.commonScreenshots])
         .call(done)
-    })
-
-    it('renders the login page correctly once the login button is clicked', function (done) {
-      client
-        .verifyScreenshots('index.homepage', [ctx.commonScreenshots])
-        .click(selectors.links.index.adminLoginButton)
-        .pause(ctx.maxTimeout)
-        .waitForExist(selectors.links.login.loginButton)
-        .waitForExist(selectors.links.login.loginForm)
-        .waitForExist(selectors.links.login.loginInputPassword)
-        .waitForExist(selectors.links.login.loginInputUsername)
-        .waitForExist(data.login.username)
-        .waitForExist(data.login.password)
-        .verifyScreenshots('login.homepage', [ctx.commonScreenshots])
-        .execute(
-          function () {
-            jQuery('.login-input input[name=username]').val('test')
-            jQuery('.login-input input[name=password]').val('password')
-          }
-        )
-        .then(() => {
-          client
-            .waitForExist(data.login.usernameInput)
-            .waitForExist(data.login.passwordInput)
-            .verifyScreenshots('login.filledOut', [ctx.commonScreenshots])
-            .call(done)
-        })
     })
   })
 }

--- a/tests/e2e/login-e2e.js
+++ b/tests/e2e/login-e2e.js
@@ -1,0 +1,52 @@
+/* global jQuery */
+'use strict'
+
+const selectors = require('./selectors')
+const data = require('./data')
+
+module.exports = function (ctx) {
+  describe(`webdriverio-server login ${ctx.url}`, () => {
+    let client
+    let homepageURL = `${ctx.url}#/`
+
+    beforeEach((done) => {
+      client = ctx.client
+      client
+        .url(homepageURL)
+        .refresh()
+        .waitForExist(selectors.links.index.signUpLink, ctx.maxTimeout)
+        .waitForExist(selectors.links.index.adminLogin, ctx.maxTimeout)
+        .waitForExist(selectors.links.index.contributingLink, ctx.maxTimeout)
+        .waitForExist(data.index.primaryLogo)
+        .waitForExist(data.index.primaryTitle)
+        .call(done)
+    })
+
+    it('renders the login page correctly once the login button is clicked', function (done) {
+      client
+        .verifyScreenshots('index.homepage', [ctx.commonScreenshots])
+        .click(selectors.links.index.adminLoginButton)
+        .pause(ctx.maxTimeout)
+        .waitForExist(selectors.links.login.loginButton)
+        .waitForExist(selectors.links.login.loginForm)
+        .waitForExist(selectors.links.login.loginInputPassword)
+        .waitForExist(selectors.links.login.loginInputUsername)
+        .waitForExist(data.login.username)
+        .waitForExist(data.login.password)
+        .verifyScreenshots('login.homepage', [ctx.commonScreenshots])
+        .execute(
+          function () {
+            jQuery('.login-input input[name=username]').val('test')
+            jQuery('.login-input input[name=password]').val('password')
+          }
+        )
+        .then(() => {
+          client
+            .waitForExist(data.login.usernameInput)
+            .waitForExist(data.login.passwordInput)
+            .verifyScreenshots('login.filledOut', [ctx.commonScreenshots])
+            .call(done)
+        })
+    })
+  })
+}

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "1284",
+        "port": "1964",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:1284/"
+    "url": "http://localhost:1964/"
 }

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "1529",
+        "port": "1329",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:1529/"
+    "url": "http://localhost:1329/"
 }

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "1779",
+        "port": "1284",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:1779/"
+    "url": "http://localhost:1284/"
 }

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "2135",
+        "port": "1529",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:2135/"
+    "url": "http://localhost:1529/"
 }

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "1181",
+        "port": "2135",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:1181/"
+    "url": "http://localhost:2135/"
 }

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "1434",
+        "port": "1421",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:1434/"
+    "url": "http://localhost:1421/"
 }

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "1964",
+        "port": "1279",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:1964/"
+    "url": "http://localhost:1279/"
 }

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "1279",
+        "port": "1434",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:1279/"
+    "url": "http://localhost:1434/"
 }

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "2157",
+        "port": "1181",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:2157/"
+    "url": "http://localhost:1181/"
 }

--- a/tests/e2e/test-config.json
+++ b/tests/e2e/test-config.json
@@ -6,9 +6,9 @@
     },
     "http": {
         "host": "localhost",
-        "port": "1329",
+        "port": "1779",
         "entryPoint": "/"
     },
     "seleniumServer": "localhost",
-    "url": "http://localhost:1329/"
+    "url": "http://localhost:1779/"
 }


### PR DESCRIPTION
# MAJOR
# CHANGELOG
- Added the ability for a server to be either a master or slave server
- Allowed for a slave server to process multiple requests from a single client
- Allowed for a master server to send separate tests to different servers and combine those results and pass them back to the client
- Updated the script to deploy a master or slave server depending on a flag
