### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "circular-json": "^0.3.0",
     "cookie-parser": "~1.3.4",
     "debug": "~2.1.1",
-    "express": "~4.12.2",
+    "express": "~4.14.0",
     "express-session": "^1.10.1",
     "github": "^2.0.1",
     "jade": "~1.9.2",


### PR DESCRIPTION
# patch

webdriverio-server is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:negotiator:20160616). 

Vulnerable module: `negotiator`
Introduced through: `express`

This PR fixes the ReDOS vulnerability by upgrading `express` to version 4.14.0

Check out the [Snyk test report](https://snyk.io/test/github/ciena-blueplanet/webdriverio-server) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
